### PR TITLE
Covers from inner folders

### DIFF
--- a/cfg.json
+++ b/cfg.json
@@ -42,7 +42,8 @@
     ],
     "excluded_file_formats":[
         "^thumb_",
-        "^cover_"
+        "^cover_",
+        "^default_"
     ],
     "template_path": "templates/default.html",
     "thumbnail_size": {
@@ -55,5 +56,6 @@
     },
     "regenerate_thumbnails": false,
     "directories_on_a_row": 3,
-    "images_on_a_row": 3
+    "images_on_a_row": 3,
+    "default_image": "default_images/default_.jpg"
 }

--- a/teca/ConfigHandler.py
+++ b/teca/ConfigHandler.py
@@ -50,7 +50,6 @@ class ConfigHandler(object):
         """Internal"""
 
         #if we're called, we are sure that the json is valid and a valid config_dict has been generated
-        
         root_cfg = FolderConfig(config_dict)
         
         if father_obj: father_obj.paths = dict()
@@ -58,8 +57,6 @@ class ConfigHandler(object):
         
         converted_paths=dict()
         for subfolder_name, subfolder_config in root_cfg.paths.iteritems():
-            #os.path.abspath used in order to fix a "can't find configuration for this folder" warning
-            #converted_paths[os.path.abspath(subfolder_name)] = self.adapt(subfolder_config, root_cfg, ind+1)
             converted_paths[subfolder_name] = self.adapt(subfolder_config, root_cfg, ind+1)
         root_cfg.paths=converted_paths
         return root_cfg
@@ -109,9 +106,8 @@ class ConfigHandler(object):
         #other/another/more/folder/name
         #and, in file, it's like
         #"paths":{"other":{"another":{"more":{"folder":{"name":{}}}}}}
-        #using os.path.abspath on @path in order to fix the warning.
-        #path = os.path.abspath(path)
-        path = os.path.abspath(path).replace(os.path.abspath(self.starting_path), "")
+        #using os.path.abspath on @path in order to fix the warning given at KeyError
+        path = path.replace(os.path.abspath(self.starting_path), "")
         obj_from_path = self.config.config #self.config["paths"]
         try:
             for subpath in filter(bool, path.split(os.path.sep)):
@@ -200,3 +196,7 @@ class ConfigHandler(object):
             return self.config["algorithm"]
         except KeyError:
             return 'md5'
+
+    @property
+    def default_image(self):
+        return self.config["default_image"]


### PR DESCRIPTION
## Bugfix
- Folder-specific Configuration is now applied correctly

e.g: if you called Teca this way

```
alfateam@broken ~/projects/Teca
$ python teca.py ../../screens/
```

you received a lot of warnings, because Teca applied "../../screens" before the real name of the folder, so configuration for a specified folder was not recognized (and therefore applied).
Now it's fixed.
- No more broken Covers images

In case no images were contained in the folder, a void (=> broken) "cover_.png" file were created.
From now on, the image is randomly chosen between the images in the inner folders. In case no images are present, a default image is used as cover image.
The path of the default image can be set in the configuration file (_default_image_ keyword)
## Misc
- Restored "templates/default.html" as default theme
