### PR TITLE
mockfs on PyPI is outdated (aka: fix-travis-1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.4"
   - "nightly"
 # command to install dependencies
-install: "pip install pip --upgrade ; pip install --upgrade .[test]"
+install: "pip install pip --upgrade ; pip install --upgrade .[test] -r requirements.txt"
 # command to run tests
 script:
   #- mkdir -p tests/test_data/images/emptyFolder

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ python:
   - "3.4"
   - "nightly"
 # command to install dependencies
-install: "pip install --upgrade ."
+install: "pip install --upgrade .[test]"
 # command to run tests
 script:
   #- mkdir -p tests/test_data/images/emptyFolder
-  - python setup.py test
+  #- python setup.py test
+  - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.4"
   - "nightly"
 # command to install dependencies
-install: "pip install --upgrade .[test]"
+install: "pip install pip --upgrade ; pip install --upgrade .[test]"
 # command to run tests
 script:
   #- mkdir -p tests/test_data/images/emptyFolder

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+http://github.com/mockfs/mockfs

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "six"
     ],
     extras_require={
-        "test": ["nose", "mockfs", "coverage"]
+            "test": ["nose", "coverage"]
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -54,8 +54,6 @@ class SameConfClass(object):
                 }
             }
         })
-        for p, d, f in os.walk("tests"):
-            print(p, d, f)
 
     def tearDown(self):
         mockfs.restore_builtins()


### PR DESCRIPTION
tl;dr travis croaks because no test dependencies and https://github.com/mockfs/mockfs/issues/7

long version: at first, test dependencies were not installed automatically on travis. after fixing this particular problem, it was time to find out the version of mockfs on PyPI is outdated.
